### PR TITLE
Spawn

### DIFF
--- a/bound_dist.py
+++ b/bound_dist.py
@@ -117,7 +117,8 @@ def bound_dist(log, field, dryrun, prefix, survey, nproc, realz, nooverwrite, co
 
     runtime = calc_runtime(start, 'POOL:  Expected runtime of {:.3f}.'.format(nchunk * split_time))
 
-    with Pool(nproc) as pool:
+    # https://britishgeologicalsurvey.github.io/science/python-forking-vs-spawn/
+    with multiprocessing.get_context('spawn').Pool(nproc) as pool:
         for result in tqdm.tqdm(pool.imap(process_one, iterable=runs[1:]), total=len(runs[1:])):
             results.append(result)
 

--- a/fillfactor.py
+++ b/fillfactor.py
@@ -231,7 +231,7 @@ def fillfactor(log, field, dryrun, prefix, survey, oversample, nproc, realz, noo
     done_nsplit = 1
 
     # maxtasksperchild:  restart process after max tasks to contain resource leaks;
-    with Pool(nproc, maxtasksperchild=4) as pool:
+    with multiprocessing.get_context('spawn').Pool(nproc, maxtasksperchild=4) as pool:
         total   = (nchunk-1)
 
         with tqdm.tqdm(total=total) as pbar:

--- a/gen_kEcat.py
+++ b/gen_kEcat.py
@@ -2,7 +2,8 @@ import os
 import sys
 import argparse
 import runtime
-import numpy as np
+import numpy           as     np
+import multiprocessing 
 
 from   astropy.table   import Table, vstack
 from   smith_kcorr     import GAMA_KCorrection

--- a/gen_kEcat.py
+++ b/gen_kEcat.py
@@ -93,7 +93,7 @@ def gen_kE(log, dryrun, survey, nooverwrite, nproc=12):
     # dat     = vstack(dat) 
 
     # --  Multi-processing  --
-    with Pool(nproc) as pool:
+    with multiprocessing.get_context('spawn').Pool(nproc) as pool:
         dat = vstack(pool.map(partial(sub_kE, kcorr_r=kcorr_r, kcorr_g=kcorr_g), dat))
 
         pool.close()

--- a/gen_zmax_cat.py
+++ b/gen_zmax_cat.py
@@ -4,6 +4,7 @@ import time
 import argparse
 import runtime
 import numpy           as     np
+import multiprocessing
 
 from   cosmo           import distmod, volcom
 from   smith_kcorr     import GAMA_KCorrection

--- a/gen_zmax_cat.py
+++ b/gen_zmax_cat.py
@@ -65,7 +65,7 @@ def zmax(rest_gmrs_0p1, rest_gmrs_0p0, theta_zs, drs, aall=False, debug=True):
    if debug:
         print('Solving for zlimit.')
 
-   with Pool(processes=14) as pool:
+   with multiprocessing.get_context('spawn').Pool(processes=14) as pool:
        arglist = list(zip(rest_gmrs_0p1, rest_gmrs_0p0, theta_zs, drs))
        result  = pool.starmap(partial(solve_theta, aall=aall), arglist)
    

--- a/lumfn_stepwise.py
+++ b/lumfn_stepwise.py
@@ -130,7 +130,7 @@ def lumfn_stepwise_eval(vmax, dM, phi_M, phi, phi_Ms, phis, Mcol='MCOLOR_0P0', s
     
     results = []
 
-    with Pool(nproc) as pool:
+    with multiprocessing.get_context('spawn').Pool(nproc) as pool:
         # For this phi_M, per rest frame color list of the stepwise (1/<n>) weight for all galaxies in the vol. limited sample.
         for result in pool.imap(partial(process_one, Mmins=Mmins, Mmaxs=Mmaxs, dM=dM, phi_Ms=phi_Ms, phis=phis), iterable=splits):
             results.append(np.array(result))

--- a/lumfn_stepwise.py
+++ b/lumfn_stepwise.py
@@ -4,6 +4,7 @@ import  time
 import  tqdm
 import  argparse
 import  numpy           as     np
+import  multiprocessing
 
 from    runtime         import calc_runtime
 from    functools       import partial
@@ -295,19 +296,15 @@ if __name__ == '__main__':
     ddp['ZMIN']            = np.clip(ddp['ZMIN'], zlo, None)
     ddp['ZMAX']            = np.clip(ddp['ZMAX'], None, zhi)
 
-    phi_Ms, phis, nMs      = lumfn_stepwise(ddp)
-
-    result                 = Table(np.c_[phi_Ms, phis, nMs], names=['MID_M', 'PHI_STEPWISE', 'N'])
-
+    result                 = lumfn_stepwise(ddp)
+    '''
     runtime                = calc_runtime(start, 'Writing {}'.format(opath))    
-
-    result.meta['IMMUTABLE'] = 'FALSE'
 
     print(f'Writing {opath}')
     
     write_desitable(opath, result)
-
-    runtime = calc_runtime(start, 'Finished')
+    '''
+    runtime                = calc_runtime(start, 'Finished')
 
     if log:
         sys.stdout.close()


### PR DESCRIPTION
Summary:  Default on Linux is to fork, rather than spawn, which causes all variables to be cloned for a given process.  
See [Spawn vs Fork](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&ved=2ahUKEwjetOfdxo74AhVWQUEAHUEpDNMQFnoECAsQAw&url=https%3A%2F%2Fbritishgeologicalsurvey.github.io%2Fscience%2Fpython-forking-vs-spawn%2F&usg=AOvVaw1G8NYBi-jwyhkJDBIPkdjY)

This PR makes things no worse by adding the suggested context managers, all the scripts run.  But it's TBD whether this solves the problem of some jobs with pool hanging.  